### PR TITLE
Hotfix for maven build for master.

### DIFF
--- a/src/main/java/com/github/fishio/FishIO.java
+++ b/src/main/java/com/github/fishio/FishIO.java
@@ -103,6 +103,9 @@ public class FishIO extends Application {
 	 * Set up new logger.
 	 */
 	protected final void initiateLogger() {
+		//Remove any Handlers if, for GUI tests.
+		log.removeAllHandlers();
+		
 		//Set Handlers with formatters
 		log.addHandler(consoleHandler);
 		log.addHandler(textFileHandler);

--- a/src/test/java/com/github/fishio/logging/TestLog.java
+++ b/src/test/java/com/github/fishio/logging/TestLog.java
@@ -28,6 +28,9 @@ public class TestLog {
 		mockedHandler1 = Mockito.mock(ConsoleHandler.class);
 		mockedHandler2 = Mockito.mock(ConsoleHandler.class);
 		log = Log.getLogger();
+		//Clean up logger.
+		log.removeAllHandlers();
+		log.setLogLevel(LogLevel.WARNING);
 	}
 	
 	/**


### PR DESCRIPTION
The GUI tests keep the logger loaded, which meant that each time the a new
GUI test was ran, new handlers were added to Logger. This slows down the
maven build and caused the logger tests to fail, which where ran after the
GUI test in maven build. Cleaned up initiliazation of loggers + made sure
the TestLog class always uses a clean logger for it's tests.

<bug
