### PR TITLE
BugFix where postTick isn't called on TicListeners

### DIFF
--- a/src/main/java/com/github/fishio/listeners/Listenable.java
+++ b/src/main/java/com/github/fishio/listeners/Listenable.java
@@ -61,7 +61,7 @@ public interface Listenable {
 	default void callPostTick(String logPrefix) {
 		for (TickListener tl : getListeners()) {
 			try {
-				tl.preTick();
+				tl.postTick();
 			} catch (Exception ex) {
 				if (logPrefix != null) {
 					Log.getLogger().log(LogLevel.ERROR, "[" + logPrefix + "] Error in preTick:\t" + ex.getMessage());


### PR DESCRIPTION
The callPostTick method in Listenable calls the preTick method on the
TickListener instead of the postTick.

This is a very small bug and should be merged as soon as possible. Code review should take at most ten seconds.

<bug
