### PR TITLE
Fix achievement bug

### DIFF
--- a/src/main/java/com/github/fishio/control/AchievementScreenController.java
+++ b/src/main/java/com/github/fishio/control/AchievementScreenController.java
@@ -69,23 +69,23 @@ public class AchievementScreenController implements ScreenController {
 	public void setPlayerDeath() {
 		Achieve.checkPlayerDeath(playerDeath);
 		
-		if (playerDeath.getLevel() == 1) {
+		if (playerDeath.getLevel() >= 1) {
 			smallachieve11.setOpacity(1);
 			log.log(LogLevel.INFO, "Glutton achievement level 1 gained!");
 		}
-		if (playerDeath.getLevel() == 2) {
+		if (playerDeath.getLevel() >= 2) {
 			smallachieve12.setOpacity(1);
 			log.log(LogLevel.INFO, "Glutton achievement level 2 gained!");
 		}
-		if (playerDeath.getLevel() == 3) {
+		if (playerDeath.getLevel() >= 3) {
 			smallachieve13.setOpacity(1);
 			log.log(LogLevel.INFO, "Glutton achievement level 3 gained!");
 		}
-		if (playerDeath.getLevel() == 4) {
+		if (playerDeath.getLevel() >= 4) {
 			smallachieve14.setOpacity(1);
 			log.log(LogLevel.INFO, "Glutton achievement level 4 gained!");
 		}
-		if (playerDeath.getLevel() == 5) {
+		if (playerDeath.getLevel() >= 5) {
 			smallachieve15.setOpacity(1);
 			log.log(LogLevel.INFO, "Glutton achievement level 5 gained!");
 		}
@@ -96,23 +96,23 @@ public class AchievementScreenController implements ScreenController {
 	 */
 		public void setEnemyKill() {
 			Achieve.checkEnemyKill(enemyKill);
-			if (enemyKill.getLevel() == 1) {
+			if (enemyKill.getLevel() >= 1) {
 				smallachieve21.setOpacity(1);
 			log.log(LogLevel.INFO, "Survival of the fittest achievement level 1 gained!");
 			}
-			if (enemyKill.getLevel() == 2) {
+			if (enemyKill.getLevel() >= 2) {
 				smallachieve22.setOpacity(1);
 			log.log(LogLevel.INFO, "Survival of the fittest achievement level 2 gained!");
 			}
-			if (enemyKill.getLevel() == 3) {
+			if (enemyKill.getLevel() >= 3) {
 				smallachieve23.setOpacity(1);
 			log.log(LogLevel.INFO, "Survival of the fittest achievement level 3 gained!");
 			}
-			if (enemyKill.getLevel() == 4) {
+			if (enemyKill.getLevel() >= 4) {
 				smallachieve24.setOpacity(1);
 			log.log(LogLevel.INFO, "Survival of the fittest achievement level 4 gained!");
 			}
-			if (enemyKill.getLevel() == 5) {
+			if (enemyKill.getLevel() >= 5) {
 				smallachieve25.setOpacity(1);
 			log.log(LogLevel.INFO, "Survival of the fittest achievement level 5 gained!");
 			}


### PR DESCRIPTION
When obtaining the second level of an achievement, the first level was
disabled again in the achievement screen. This small commit fixes this.

<bug
