### PR TITLE
Fixed tradition breaker design flaw

### DIFF
--- a/src/main/java/com/github/fishio/power_ups/DurationPowerUp.java
+++ b/src/main/java/com/github/fishio/power_ups/DurationPowerUp.java
@@ -73,16 +73,6 @@ public abstract class DurationPowerUp extends PowerUp implements TickListener {
 	public abstract void startEffect();
 	
 	/**
-	 * The effect that should happen each time before a game tick.
-	 */
-	public abstract void preTickEffect();
-	
-	/**
-	 * The effect that should happen each time after a game tick.
-	 */
-	public abstract void postTickEffect();
-	
-	/**
 	 * The effect that should happen after the duration of the PowerUp.
 	 */
 	public abstract void endEffect();
@@ -93,11 +83,6 @@ public abstract class DurationPowerUp extends PowerUp implements TickListener {
 		if (!active) {
 			return;
 		}
-		
-		if (tickCounter >= 1) {
-			preTickEffect();
-		}
-			
 	}
 	
 	@Override
@@ -115,8 +100,6 @@ public abstract class DurationPowerUp extends PowerUp implements TickListener {
 			active = false;
 			return;
 		}
-		
-		postTickEffect();
 	}
 	
 	/**

--- a/src/main/java/com/github/fishio/power_ups/PuFreeze.java
+++ b/src/main/java/com/github/fishio/power_ups/PuFreeze.java
@@ -61,12 +61,6 @@ public class PuFreeze extends DurationPowerUp {
 		}
 	}
 
-	@Override
-	public void preTickEffect() { }
-
-	@Override
-	public void postTickEffect() { }
-
 	/** 
 	 * Resets the behaviour of the EnemyFishes.
 	 */

--- a/src/main/java/com/github/fishio/power_ups/PuSuperSpeed.java
+++ b/src/main/java/com/github/fishio/power_ups/PuSuperSpeed.java
@@ -61,12 +61,6 @@ public class PuSuperSpeed extends DurationPowerUp {
 		keyBehaviour.setMaxSpeed(keyBehaviour.getMaxSpeed() * MAX_SPEED_FACTOR);
 	}
 
-	@Override
-	public void preTickEffect() { }
-
-	@Override
-	public void postTickEffect() { }
-
 	/** 
 	 * Restores the acceleration and the MaxSpeed of
 	 * the PlayerFish we just drugged.

--- a/src/test/java/com/github/fishio/power_ups/TestDurationPowerUp.java
+++ b/src/test/java/com/github/fishio/power_ups/TestDurationPowerUp.java
@@ -82,7 +82,6 @@ public abstract class TestDurationPowerUp extends TestPowerUp {
 		pu.preTick();
 		
 		assertEquals(0, pu.getTickCounter());
-		Mockito.verify(pu, never()).preTickEffect();
 	}
 	
 	/**
@@ -99,7 +98,6 @@ public abstract class TestDurationPowerUp extends TestPowerUp {
 		pu.preTick();
 		
 		assertEquals(1, pu.getTickCounter());
-		Mockito.verify(pu).preTickEffect();
 	}
 	
 	/**
@@ -115,7 +113,6 @@ public abstract class TestDurationPowerUp extends TestPowerUp {
 		pu.preTick();
 		
 		assertEquals(0, pu.getTickCounter());
-		Mockito.verify(pu, never()).preTickEffect();
 	}
 	
 	/**
@@ -128,7 +125,6 @@ public abstract class TestDurationPowerUp extends TestPowerUp {
 		pu.postTick();
 		
 		assertEquals(0, pu.getTickCounter());
-		Mockito.verify(pu, never()).postTickEffect();
 		Mockito.verify(pu, never()).endEffect();
 		assertFalse(pu.isActive());
 	}
@@ -147,7 +143,6 @@ public abstract class TestDurationPowerUp extends TestPowerUp {
 		pu.postTick();
 		
 		assertEquals(pu.getTimeTicks(), pu.getTickCounter());
-		Mockito.verify(pu, never()).postTickEffect();
 		Mockito.verify(pu).endEffect();
 		assertFalse(pu.isActive());
 		
@@ -170,7 +165,6 @@ public abstract class TestDurationPowerUp extends TestPowerUp {
 		pu.postTick();
 		
 		assertEquals(pu.getTimeTicks() - 1, pu.getTickCounter());
-		Mockito.verify(pu).postTickEffect();
 		Mockito.verify(pu, never()).endEffect();
 		assertTrue(pu.isActive());
 		


### PR DESCRIPTION
DurationPowerUp no longer has an abstract pre/postTickEffect method.
PowerUps that want this feature in the future should implement the
TickListener. It does exactly the same thing.

<organisation
